### PR TITLE
Add immutable CodeEditorState with undo/redo functionality

### DIFF
--- a/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/CodeEditorHistory.java
+++ b/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/CodeEditorHistory.java
@@ -1,0 +1,36 @@
+package com.ru.pattern.inmutability_copy.CodeEditorEx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class CodeEditorHistory {
+
+    private List<CodeEditorState> history = new ArrayList<>();
+    private int currentIndex = -1;
+
+    void save(CodeEditorState state) {
+        if (this.currentIndex < this.history.size() - 1) {
+            this.history.subList(currentIndex + 1, history.size()).clear();
+        }
+        history.add(state);
+        currentIndex++;
+
+    }
+
+    Optional<CodeEditorState> unDo(){
+        if(this.currentIndex > 0){
+            this.currentIndex--;
+            return Optional.of(history.get(currentIndex));
+        }
+        return Optional.empty();
+    }
+
+    Optional<CodeEditorState> reDo(){
+        if(this.currentIndex < this.history.size() - 1){
+            this.currentIndex++;
+            return Optional.of(history.get(currentIndex));
+        }
+        return Optional.empty();
+    }
+}

--- a/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/CodeEditorState.java
+++ b/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/CodeEditorState.java
@@ -1,0 +1,35 @@
+package com.ru.pattern.inmutability_copy.CodeEditorEx;
+
+public class CodeEditorState {
+    private final String content;
+    private final int cursorPosition;
+    private final boolean unsavedChanges;
+
+    public CodeEditorState(String content, int cursorPosition, boolean unsavedChanges) {
+        this.content = content;
+        this.cursorPosition = cursorPosition;
+        this.unsavedChanges = unsavedChanges;
+    }
+
+    public CodeEditorState copyWith(String content, Integer cursorPosition, Boolean unsavedChanges) {
+        return new CodeEditorState(
+                content != null ? content : this.content,
+                cursorPosition != null ? cursorPosition : this.cursorPosition,
+                unsavedChanges != null ? unsavedChanges : this.unsavedChanges
+        );
+    }
+
+
+    public void displayState() {
+        System.out.println(this);
+    }
+
+    @Override
+    public String toString() {
+        return "CodeEditorState{" +
+                "content='" + content + '\'' +
+                ", cursorPosition=" + cursorPosition +
+                ", unsavedChanges=" + unsavedChanges +
+                '}';
+    }
+}

--- a/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/InmutabilityExample.java
+++ b/patterns-practice/src/main/java/com/ru/pattern/inmutability_copy/CodeEditorEx/InmutabilityExample.java
@@ -1,0 +1,43 @@
+package com.ru.pattern.inmutability_copy.CodeEditorEx;
+
+public class InmutabilityExample {
+
+    public static void main(String[] args) {
+
+        CodeEditorHistory history = new CodeEditorHistory();
+        CodeEditorState state = new CodeEditorState("console.log('hola Mundo!');", 2, false);
+
+        history.save(state);
+
+        System.out.print("Estado inicial: ");
+        state.displayState();
+
+        state = state.copyWith("console.log('hola Mundo!'); \nconsole.log('Nueva Linea');", 3, true);
+
+        history.save(state);
+
+        System.out.print("Estado dos: ");
+        state.displayState();
+
+        state = state.copyWith(null,5,null);
+
+        history.save(state);
+
+        System.out.print("Estado tres: ");
+        state.displayState();
+
+        state = history.unDo().orElseThrow(() -> new IllegalStateException("No previous state to undo to"));
+        
+        System.out.print("Despues del undo: ");
+        state.displayState();
+
+        state = history.reDo().orElseThrow(() -> new IllegalStateException("No next state to redo to"));
+
+        System.out.print("Despues del undo: ");
+        state.displayState();
+
+
+
+    }
+}
+


### PR DESCRIPTION
Introduced CodeEditorState to represent the editor's immutable state. Implemented CodeEditorHistory to manage undo/redo operations. Demonstrated functionality in InmutabilityExample with multiple state transitions.